### PR TITLE
Item变换出错

### DIFF
--- a/WXTabBarController/Source/WXTabBarController.m
+++ b/WXTabBarController/Source/WXTabBarController.m
@@ -183,6 +183,8 @@
             [self tabBarButton:tabBarButton highlighted:YES deltaAlpha:deltaAlpha];
         } else if (idx == index + 1) {
             [self tabBarButton:tabBarButton highlighted:NO deltaAlpha:deltaAlpha];
+        } else {
+            [self tabBarButton:tabBarButton highlighted:NO deltaAlpha:0];
         }
     }];
 }


### PR DESCRIPTION
使用5个Item, 然后快速的切换，发现有一些item的颜色还有浅色，所以加了这小段代码修复一下。

另外解决滑动冲突的问题可以用这个来解决，不过是跟手势区分，别的需求还需再次研究。 滑动的代码没有提交，因为没有完全的测试。
- (void) requireGestureRecognizer: (UIGestureRecognizer *) gesture {
  [self.scrollView.panGestureRecognizer
  requireGestureRecognizerToFail:gesture];
  }

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leichunfeng/wxtabbarcontroller/14)

<!-- Reviewable:end -->
